### PR TITLE
Original表示の不具合、読み込み案内を改善

### DIFF
--- a/components/ColorChart.vue
+++ b/components/ColorChart.vue
@@ -8,7 +8,14 @@ import Chart from 'chart.js/auto'
 
 interface Props {
   title: string
-  data: { color: string; value: number }[]
+  data: {
+    color: string
+    displayColor?: string
+    value: number
+    previewColor?: string
+    copyColor?: string
+    originalColor?: string
+  }[]
 }
 
 const props = defineProps<Props>()
@@ -32,11 +39,11 @@ const renderChart = async () => {
   chartInstance.value = new Chart(ctx, {
     type: 'doughnut',
     data: {
-      labels: props.data.map((d) => d.color),
+      labels: props.data.map((d) => d.displayColor ?? d.color),
       datasets: [
         {
           data: props.data.map((d) => d.value),
-          backgroundColor: props.data.map((d) => d.color),
+          backgroundColor: props.data.map((d) => d.previewColor ?? d.color),
         },
       ],
     },
@@ -46,7 +53,14 @@ const renderChart = async () => {
         legend: { display: false },
         tooltip: {
           callbacks: {
-            label: (tooltipItem) => props.data[tooltipItem.dataIndex].color,
+            label: (tooltipItem) => {
+              const color = props.data[tooltipItem.dataIndex]
+              if (color.originalColor) {
+                return `${color.displayColor ?? color.color} ${color.originalColor}`
+              }
+
+              return color.displayColor ?? color.color
+            },
           },
         },
         title: { display: true, text: props.title },
@@ -63,7 +77,7 @@ const renderChart = async () => {
     )
     if (elements?.length) {
       const index = elements[0].index
-      const clickedColor = props.data[index].color
+      const clickedColor = props.data[index].copyColor ?? props.data[index].color
       emit('color-clicked', clickedColor)
     }
   }

--- a/components/ColorList.vue
+++ b/components/ColorList.vue
@@ -2,17 +2,23 @@
   <div class="flex flex-wrap items-start">
     <div
       v-for="color in colors"
-      :key="color.color"
-      @click="$emit('color-clicked', color.color)"
+      :key="`${color.color}-${color.previewColor ?? color.color}`"
+      @click="$emit('color-clicked', color.copyColor ?? color.color)"
       class="inline-flex items-start w-1/2 cursor-pointer"
     >
       <div
-        :style="{ background: color.color }"
-        :data-color="color.color"
+        :style="{ background: color.previewColor ?? color.color }"
+        :data-color="color.displayColor ?? color.color"
         class="mt-[8px] w-[30px] min-w-[30px] h-[15px] border border-white box-border"
       ></div>
-      <p :data-color="color.color" class="pl-[5px] text-[14px] my-[5px] text-gray">
-        {{ color.color }}
+      <p
+        :data-color="color.displayColor ?? color.color"
+        class="pl-[5px] text-[14px] my-[5px] text-gray leading-tight"
+      >
+        <span class="block">{{ color.displayColor ?? color.color }}</span>
+        <span v-if="color.originalColor" class="block text-[12px]">
+          {{ color.originalColor }}
+        </span>
       </p>
     </div>
   </div>
@@ -20,7 +26,14 @@
 
 <script setup lang="ts">
 defineProps<{
-  colors: { color: string; value: number }[]
+  colors: {
+    color: string
+    displayColor?: string
+    value: number
+    previewColor?: string
+    copyColor?: string
+    originalColor?: string
+  }[]
 }>()
 
 defineEmits<{

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -40,12 +40,17 @@ export default defineContentScript({
     let allBackgroundColors: {
       element: Element | null
       color: string
+      computedColor: string
       area: number
       children: Element[]
     }[] = []
+    let authoredStyleLookupDeadline = 0
 
     chrome.runtime.onMessage.addListener((_request, _sender, sendResponse) => {
       allBackgroundColors = []
+      cachedAuthoredStyleRules = null
+      authoredStyleLookupDeadline = performance.now() + 500
+      const authoredStyleRules = getAuthoredStyleRules()
 
       const parentElements = getColorElement([htmlElement])
       totalElementArea(parentElements).forEach((v) => allBackgroundColors.push(v))
@@ -66,7 +71,8 @@ export default defineContentScript({
       if (htmlArea) {
         allBackgroundColors.push({
           element: htmlElement,
-          color: htmlBg,
+          color: getDeclaredColor(htmlElement, 'background-color', authoredStyleRules) ?? htmlBg,
+          computedColor: htmlBg,
           area: Math.max(window.innerWidth * window.innerHeight - otherArea, 0),
           children: Array.from(htmlElement.children),
         })
@@ -74,6 +80,7 @@ export default defineContentScript({
         allBackgroundColors.push({
           element: null,
           color: 'rgb(255, 255, 255)',
+          computedColor: 'rgb(255, 255, 255)',
           area: Math.max(window.innerWidth * window.innerHeight - otherArea, 0),
           children: [],
         })
@@ -83,11 +90,12 @@ export default defineContentScript({
         (el) => !notApplicableTags.includes(el.tagName.toUpperCase()) && isVisibleElement(el)
       )
 
-      const allTextColors: { colorCode: string; area: number }[] = []
+      const allTextColors: { colorCode: string; computedColor: string; area: number }[] = []
 
       elements.forEach((element) => {
-        const color = window.getComputedStyle(element).color
-        if (isVisibleColor(color)) {
+        const computedColor = window.getComputedStyle(element).color
+        if (isVisibleColor(computedColor)) {
+          const color = resolveInheritedDeclaredColor(element, authoredStyleRules) ?? computedColor
           let textLength = 0
           const tag = element.tagName.toUpperCase()
 
@@ -103,6 +111,7 @@ export default defineContentScript({
           if (textLength) {
             allTextColors.push({
               colorCode: color,
+              computedColor,
               area: textLength,
             })
           }
@@ -110,10 +119,18 @@ export default defineContentScript({
       })
 
       const backgroundColors = countColors(
-        allBackgroundColors.map((c) => ({ color: c.color, value: c.area }))
+        allBackgroundColors.map((c) => ({
+          color: c.color,
+          computedColor: c.computedColor,
+          value: c.area,
+        }))
       )
       const textColors = countColors(
-        allTextColors.map((c) => ({ color: c.colorCode, value: c.area }))
+        allTextColors.map((c) => ({
+          color: c.colorCode,
+          computedColor: c.computedColor,
+          value: c.area,
+        }))
       )
 
       sendResponse({ backgroundColors, textColors })
@@ -209,16 +226,21 @@ export default defineContentScript({
      * @param {Element[]} element - 対象のHTML要素
      * @returns {string} カラーコード
      */
-    const resolveEffectiveBackgroundColor = (element: Element): string => {
+    const resolveEffectiveBackgroundColor = (
+      element: Element
+    ): { color: string; computedColor: string } => {
       let current: Element | null = element
       while (current) {
         const bg = window.getComputedStyle(current).backgroundColor
         if (isOpaqueBackgroundColor(bg)) {
-          return bg
+          return {
+            color: getDeclaredColor(current, 'background-color', getAuthoredStyleRules()) ?? bg,
+            computedColor: bg,
+          }
         }
         current = current.parentElement
       }
-      return 'rgb(255, 255, 255)'
+      return { color: 'rgb(255, 255, 255)', computedColor: 'rgb(255, 255, 255)' }
     }
 
     /**
@@ -260,14 +282,18 @@ export default defineContentScript({
         return getColorElement(elements)
       }
 
-      return elements.map((element) => ({
-        element,
-        color: resolveEffectiveBackgroundColor(element),
-        area: element.clientWidth * element.clientHeight,
-        children: Array.from(element.children).filter(
-          (el) => !notApplicableTags.includes(el.tagName.toUpperCase()) && isVisibleElement(el)
-        ),
-      }))
+      return elements.map((element) => {
+        const backgroundColor = resolveEffectiveBackgroundColor(element)
+        return {
+          element,
+          color: backgroundColor.color,
+          computedColor: backgroundColor.computedColor,
+          area: element.clientWidth * element.clientHeight,
+          children: Array.from(element.children).filter(
+            (el) => !notApplicableTags.includes(el.tagName.toUpperCase()) && isVisibleElement(el)
+          ),
+        }
+      })
     }
 
     /**
@@ -279,6 +305,7 @@ export default defineContentScript({
       elements: {
         element: Element
         color: string
+        computedColor: string
         area: number
         children: Element[]
       }[]
@@ -290,7 +317,7 @@ export default defineContentScript({
         )
           return
 
-        const childElements = getDirectVisibleBackgroundChildren(el.element, el.color)
+        const childElements = getDirectVisibleBackgroundChildren(el.element, el.computedColor)
         const total = childElements.reduce((sum, c) => sum + c.area, 0)
         el.area = Math.max(el.area - total, 0)
       })
@@ -333,6 +360,7 @@ export default defineContentScript({
       elements: {
         element: Element
         color: string
+        computedColor: string
         area: number
         children: Element[]
       }[]
@@ -357,15 +385,161 @@ export default defineContentScript({
      * @returns {{ color: string, value: number }[]} 集計後の色データ
      */
     const countColors = (
-      data: { color: string; value: number }[]
-    ): { color: string; value: number }[] => {
-      const count: Record<string, number> = {}
+      data: { color: string; computedColor: string; value: number }[]
+    ): { color: string; computedColor: string; value: number }[] => {
+      const count = new Map<string, { color: string; computedColor: string; value: number }>()
 
-      data.forEach(({ color, value }) => {
-        if (color) count[color] = (count[color] || 0) + value
+      data.forEach(({ color, computedColor, value }) => {
+        if (!color) return
+
+        const key = `${color}\n${computedColor}`
+        const current = count.get(key)
+        if (current) {
+          current.value += value
+        } else {
+          count.set(key, { color, computedColor, value })
+        }
       })
 
-      return Object.entries(count).map(([color, value]) => ({ color, value }))
+      return Array.from(count.values())
+    }
+
+    type AuthoredStyleRule = {
+      selectorText: string
+      declarations: Map<string, string>
+    }
+
+    let cachedAuthoredStyleRules: AuthoredStyleRule[] | null = null
+
+    /** ページ内CSSから、可能な範囲でCSSに書かれたままのプロパティ値を集める */
+    const getAuthoredStyleRules = (): AuthoredStyleRule[] => {
+      if (cachedAuthoredStyleRules) return cachedAuthoredStyleRules
+
+      cachedAuthoredStyleRules = []
+
+      Array.from(document.styleSheets).forEach((styleSheet) => {
+        try {
+          cachedAuthoredStyleRules?.push(...parseCssRules(Array.from(styleSheet.cssRules)))
+        } catch {
+          // Cross-origin stylesheets may not expose cssRules.
+        }
+      })
+
+      document.querySelectorAll('style').forEach((styleElement) => {
+        cachedAuthoredStyleRules?.push(...parseCssText(styleElement.textContent ?? ''))
+      })
+
+      return cachedAuthoredStyleRules
+    }
+
+    /** CSSRuleListから色指定に関係するルールを集める */
+    const parseCssRules = (rules: CSSRule[]): AuthoredStyleRule[] => {
+      const authoredRules: AuthoredStyleRule[] = []
+
+      rules.forEach((rule) => {
+        if (rule instanceof CSSStyleRule) {
+          const declarations = new Map<string, string>()
+          ;['color', 'background-color'].forEach((property) => {
+            const value = rule.style.getPropertyValue(property).trim()
+            if (value) declarations.set(property, value)
+          })
+
+          const backgroundValue = rule.style.getPropertyValue('background').trim()
+          if (backgroundValue && !declarations.has('background-color')) {
+            declarations.set('background-color', backgroundValue)
+          }
+
+          if (declarations.size) {
+            authoredRules.push({ selectorText: rule.selectorText, declarations })
+          }
+        } else if ('cssRules' in rule) {
+          authoredRules.push(...parseCssRules(Array.from((rule as CSSGroupingRule).cssRules)))
+        }
+      })
+
+      return authoredRules
+    }
+
+    /** styleタグ内の生CSSから色指定を取り出す */
+    const parseCssText = (cssText: string): AuthoredStyleRule[] => {
+      const rules: AuthoredStyleRule[] = []
+      const withoutComments = cssText.replace(/\/\*[\s\S]*?\*\//g, '')
+      const rulePattern = /([^{}@][^{}]*)\{([^{}]*)\}/g
+      let match: RegExpExecArray | null
+
+      while ((match = rulePattern.exec(withoutComments))) {
+        const declarations = getColorDeclarations(match[2])
+        if (declarations.size) {
+          rules.push({ selectorText: match[1].trim(), declarations })
+        }
+      }
+
+      return rules
+    }
+
+    /** 宣言ブロックから色指定だけを取り出す */
+    const getColorDeclarations = (declarationText: string): Map<string, string> => {
+      const declarations = new Map<string, string>()
+
+      declarationText.split(';').forEach((declaration) => {
+        const separatorIndex = declaration.indexOf(':')
+        if (separatorIndex < 0) return
+
+        const property = declaration.slice(0, separatorIndex).trim().toLowerCase()
+        const value = declaration.slice(separatorIndex + 1).trim()
+        if (!value) return
+
+        if (property === 'color' || property === 'background-color') {
+          declarations.set(property, value)
+        } else if (property === 'background' && !declarations.has('background-color')) {
+          declarations.set('background-color', value)
+        }
+      })
+
+      return declarations
+    }
+
+    /** 要素に指定されたCSS値を、可能な限り変換前の文字列で取得する */
+    const getDeclaredColor = (
+      element: Element,
+      property: 'color' | 'background-color',
+      authoredStyleRules: AuthoredStyleRule[]
+    ): string | null => {
+      const inlineColor = getColorDeclarations(element.getAttribute('style') ?? '').get(property)
+      if (inlineColor) return inlineColor
+
+      let matchedColor: string | null = null
+
+      for (const rule of authoredStyleRules) {
+        if (performance.now() > authoredStyleLookupDeadline) return matchedColor
+
+        try {
+          if (element.matches(rule.selectorText)) {
+            matchedColor = rule.declarations.get(property) ?? matchedColor
+          }
+        } catch {
+          // Unsupported selectors should not prevent color extraction.
+        }
+      }
+
+      return matchedColor
+    }
+
+    /** 継承される文字色の指定値を祖先から辿って取得する */
+    const resolveInheritedDeclaredColor = (
+      element: Element,
+      authoredStyleRules: AuthoredStyleRule[]
+    ): string | null => {
+      let current: Element | null = element
+
+      while (current) {
+        const declaredColor = getDeclaredColor(current, 'color', authoredStyleRules)
+        if (declaredColor) return declaredColor
+
+        current = current.parentElement
+      }
+
+      return null
     }
   },
 })

--- a/entrypoints/popup/App.vue
+++ b/entrypoints/popup/App.vue
@@ -28,6 +28,9 @@
       <template v-if="activeTab === 0">
         <div class="chart-container">
           <Loading v-if="loading" />
+          <p v-if="loading && showSlowLoadingNotice" class="c-loading-notice">
+            {{ slowLoadingNoticeText }}
+          </p>
           <ColorChart
             v-else-if="!loading && convertedBackgroundColors.length"
             title="Background Colors"
@@ -41,6 +44,9 @@
       <template v-else-if="activeTab === 1">
         <div class="chart-container">
           <Loading v-if="loading" />
+          <p v-if="loading && showSlowLoadingNotice" class="c-loading-notice">
+            {{ slowLoadingNoticeText }}
+          </p>
           <ColorChart
             v-else-if="!loading && convertedTextColors.length"
             title="Text Colors"
@@ -57,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, type ComponentPublicInstance, type Ref } from 'vue'
+import { computed, ref, onMounted, onUnmounted, type ComponentPublicInstance, type Ref } from 'vue'
 import ColorChart from '@/components/ColorChart.vue'
 import ColorList from '@/components/ColorList.vue'
 import Loading from '@/components/Loading.vue'
@@ -72,6 +78,16 @@ type ToastExpose = {
 
 type ChartColorData = {
   color: string
+  computedColor: string
+  value: number
+}
+
+type DisplayColorData = {
+  color: string
+  displayColor: string
+  previewColor: string
+  copyColor: string
+  originalColor?: string
   value: number
 }
 
@@ -87,6 +103,9 @@ type ParsedColor = {
 const activeTab = ref<number>(0)
 const activeColorMode = ref<ColorMode>('original')
 const loading = ref<boolean>(true)
+const showSlowLoadingNotice = ref<boolean>(false)
+const slowLoadingNoticeDelayMs = 2000
+let slowLoadingTimer: number | null = null
 
 const colorModes: { label: string; value: ColorMode }[] = [
   { label: 'Original', value: 'original' },
@@ -94,14 +113,6 @@ const colorModes: { label: string; value: ColorMode }[] = [
   { label: 'HEX', value: 'hex' },
   { label: 'HSL/HSLA', value: 'hsl' },
 ]
-
-// Canvas要素
-const backgroundCanvas = ref<HTMLCanvasElement | null>(null)
-const textCanvas = ref<HTMLCanvasElement | null>(null)
-
-// Chart.js インスタンス
-const backgroundChart = ref<any>(null)
-const textChart = ref<any>(null)
 
 // データ（背景色・文字色）
 const backgroundColors: Ref<ChartColorData[]> = ref([])
@@ -130,30 +141,63 @@ const showColorConversionNotice = computed(
 /** 色域変換時の注意文言を現在の言語から取得する */
 const colorConversionNoticeText = computed(() => chrome.i18n.getMessage('Notice_color_conversion'))
 
-/** 色リスト全体を選択中の形式に変換し、同じ色になったものを再集計する */
-const convertColors = (colors: ChartColorData[], mode: ColorMode): ChartColorData[] => {
-  const grouped = new Map<string, number>()
+/** 読み込みが長い場合の案内文を現在の言語から取得する */
+const slowLoadingNoticeText = computed(() => chrome.i18n.getMessage('Notice_slow_loading'))
 
-  colors.forEach(({ color, value }) => {
-    const convertedColor = convertColor(color, mode)
-    grouped.set(convertedColor, (grouped.get(convertedColor) ?? 0) + value)
+/** 色リスト全体を選択中の形式に変換し、同じ色になったものを再集計する */
+const convertColors = (colors: ChartColorData[], mode: ColorMode): DisplayColorData[] => {
+  const grouped = new Map<string, DisplayColorData>()
+
+  colors.forEach(({ color, computedColor, value }) => {
+    const convertedColor = convertColor(color, computedColor, mode)
+    const previewColor = mode === 'original' ? computedColor : convertedColor
+    const showOriginalVariable = mode === 'original' && isCssVariableColor(color)
+    const displayColor = showOriginalVariable ? formatResolvedColor(computedColor) : convertedColor
+    const copyColor = mode === 'original' ? displayColor : convertedColor
+    const originalColor = showOriginalVariable ? color : undefined
+    const key = `${displayColor}\n${previewColor}\n${copyColor}\n${originalColor ?? ''}`
+    const current = grouped.get(key)
+
+    if (current) {
+      current.value += value
+    } else {
+      grouped.set(key, {
+        color: convertedColor,
+        displayColor,
+        previewColor,
+        copyColor,
+        originalColor,
+        value,
+      })
+    }
   })
 
-  return Array.from(grouped, ([color, value]) => ({ color, value })).sort(
-    (a, b) => b.value - a.value
-  )
+  return Array.from(grouped.values()).sort((a, b) => b.value - a.value)
 }
 
 /** 1つの色文字列を選択中の表示形式に変換する */
-const convertColor = (color: string, mode: ColorMode): string => {
+const convertColor = (color: string, computedColor: string, mode: ColorMode): string => {
   if (mode === 'original') return color
 
-  const parsedColor = parseColor(color)
-  if (!parsedColor) return color
+  const parsedColor = parseColor(computedColor) ?? parseColor(color)
+  if (!parsedColor) return computedColor || color
 
   if (mode === 'hex') return formatHexColor(parsedColor)
   if (mode === 'hsl') return formatHslColor(parsedColor)
   return formatRgbColor(parsedColor)
+}
+
+/** CSS変数参照の色指定かどうかを判定する */
+const isCssVariableColor = (color: string): boolean => {
+  return color.trim().toLowerCase().startsWith('var(')
+}
+
+/** Original表示時に併記・コピーする解決後カラーコードを作る */
+const formatResolvedColor = (color: string): string => {
+  const parsedColor = parseColor(color)
+  if (!parsedColor) return color
+
+  return formatHexColor(parsedColor)
 }
 
 /** HEX / RGB / RGBA / HSL / HSLA / LAB / LCH / OKLab / OKLCH / display-p3の色文字列を共通のRGBA値に変換する */
@@ -630,17 +674,35 @@ const copyText = (text: string): void => {
   }
 }
 
+/** ローディング状態を終了し、長時間読み込み案内を閉じる */
+const finishLoading = (): void => {
+  loading.value = false
+  showSlowLoadingNotice.value = false
+
+  if (slowLoadingTimer) {
+    window.clearTimeout(slowLoadingTimer)
+    slowLoadingTimer = null
+  }
+}
+
 // ページロード時に実行される初期化処理
 onMounted(() => {
+  slowLoadingTimer = window.setTimeout(() => {
+    if (loading.value) {
+      showSlowLoadingNotice.value = true
+    }
+  }, slowLoadingNoticeDelayMs)
+
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     const currentTab = tabs[0]
     if (!currentTab?.id) {
       console.warn('No active tab found.')
+      finishLoading()
       return
     }
 
     chrome.tabs.sendMessage(currentTab.id, {}, (val) => {
-      loading.value = false
+      finishLoading()
       // エラーハンドリング
       if (chrome.runtime.lastError) {
         // URLが取得できない場合 → アクセスできないので再読み込みを促す
@@ -695,35 +757,12 @@ onMounted(() => {
       val.textColors.sort((a: ChartColorData, b: ChartColorData) => b.value - a.value)
       backgroundColors.value = val.backgroundColors
       textColors.value = val.textColors
-
-      // グラフ描画
-      backgroundCanvas.value?.addEventListener('click', (e: MouseEvent) => {
-        const elements = backgroundChart.value?.getElementsAtEventForMode(
-          e,
-          'nearest',
-          { intersect: true },
-          false
-        )
-        if (elements?.length) {
-          const index = elements[0].index
-          copyText(backgroundColors.value[index].color)
-        }
-      })
-
-      textCanvas.value?.addEventListener('click', (e: MouseEvent) => {
-        const elements = textChart.value?.getElementsAtEventForMode(
-          e,
-          'nearest',
-          { intersect: true },
-          false
-        )
-        if (elements?.length) {
-          const index = elements[0].index
-          copyText(textColors.value[index].color)
-        }
-      })
     })
   })
+})
+
+onUnmounted(() => {
+  finishLoading()
 })
 </script>
 
@@ -760,5 +799,9 @@ onMounted(() => {
 
 .c-color-conversion-notice {
   @apply m-0 border-l-[3px] border-status-error bg-white px-[10px] py-[8px] text-[12px] font-bold leading-[1.5] text-status-error;
+}
+
+.c-loading-notice {
+  @apply mx-0 mb-[24px] mt-[-24px] text-center text-[12px] font-bold leading-[1.5] text-gray;
 }
 </style>

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -25,5 +25,8 @@
   },
   "Notice_color_conversion": {
     "message": "When converted to RGB, HEX, or HSL, LAB, LCH, OKLab, OKLCH, and display-p3 colors are converted to a close sRGB-displayable color."
+  },
+  "Notice_slow_loading": {
+    "message": "This page has many colors, so loading is taking longer than usual."
   }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -25,5 +25,8 @@
   },
   "Notice_color_conversion": {
     "message": "RGB/HEX/HSL変換時、LAB/LCH/OKLab/OKLCH/display-p3はsRGBで表示可能な近い色に変換されます。"
+  },
+  "Notice_slow_loading": {
+    "message": "色の数が多いため、読み込みに時間がかかっています。"
   }
 }

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   manifest: {
     name: '__MSG_Name__',
     description: '__MSG_Description__',
-    version: '2.1.0',
+    version: '2.1.1',
     default_locale: 'en',
     action: {
       default_title: '__MSG_Name__',


### PR DESCRIPTION
## 変更内容
- OriginalモードでCSS変数の場合、解決後のカラーコードをメイン表示し、元のCSS変数名を補足表示するように変更
- CSS変数以外のOriginal表示では、補足行を出さずカラー値のみ表示
- 色チップ・チャート描画・コピー対象を、実際に解決されたカラーコードに合わせるよう調整
- 読み込みが2秒以上続く場合に、色数が多く読み込みに時間がかかっている旨の案内を表示
